### PR TITLE
Registry thread safety

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,6 +16,6 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: '^1.21' # Specify the Go version
+        go-version: '^1.21'
     - name: Test
       run: go test -v ./...

--- a/pkg/clone/deep_cloneable.go
+++ b/pkg/clone/deep_cloneable.go
@@ -1,0 +1,5 @@
+package clone
+
+type DeepCloneable[TType any] interface {
+	DeepClone() TType
+}

--- a/pkg/clone/deep_map.go
+++ b/pkg/clone/deep_map.go
@@ -1,0 +1,9 @@
+package clone
+
+func DeepCloneMap[TKey comparable, TCloneable DeepCloneable[TCloneable]](original map[TKey]TCloneable) map[TKey]TCloneable {
+	copiedMap := make(map[TKey]TCloneable, len(original))
+	for key, copyable := range original {
+		copiedMap[key] = copyable.DeepClone()
+	}
+	return copiedMap
+}

--- a/pkg/clone/deep_map.go
+++ b/pkg/clone/deep_map.go
@@ -1,6 +1,9 @@
 package clone
 
 func DeepCloneMap[TKey comparable, TCloneable DeepCloneable[TCloneable]](original map[TKey]TCloneable) map[TKey]TCloneable {
+	if original == nil {
+		return nil
+	}
 	copiedMap := make(map[TKey]TCloneable, len(original))
 	for key, copyable := range original {
 		copiedMap[key] = copyable.DeepClone()

--- a/pkg/clone/slice.go
+++ b/pkg/clone/slice.go
@@ -1,0 +1,7 @@
+package clone
+
+func Slice[TValue any](original []TValue) []TValue {
+	fieldsCopy := make([]TValue, len(original))
+	copy(fieldsCopy, original)
+	return fieldsCopy
+}

--- a/pkg/clone/slice.go
+++ b/pkg/clone/slice.go
@@ -1,6 +1,9 @@
 package clone
 
 func Slice[TValue any](original []TValue) []TValue {
+	if original == nil {
+		return nil
+	}
 	fieldsCopy := make([]TValue, len(original))
 	copy(fieldsCopy, original)
 	return fieldsCopy

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"fmt"
 
+	"github.com/kaloseia/morphe-go/pkg/clone"
 	"github.com/kaloseia/morphe-go/pkg/yaml"
 	"github.com/kaloseia/morphe-go/pkg/yamlfile"
 )
@@ -13,6 +14,15 @@ const EntityFileSuffix = ".ent"
 type Registry struct {
 	Models   map[string]yaml.Model  `yaml:"models"`
 	Entities map[string]yaml.Entity `yaml:"entities"`
+}
+
+func (r *Registry) DeepClone() *Registry {
+	registryCopy := &Registry{
+		Models:   clone.DeepCloneMap(r.Models),
+		Entities: clone.DeepCloneMap(r.Entities),
+	}
+
+	return registryCopy
 }
 
 func (registry *Registry) LoadModelsFromDirectory(dirPath string) error {

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/kaloseia/morphe-go/pkg/clone"
 	"github.com/kaloseia/morphe-go/pkg/yaml"
@@ -12,67 +13,136 @@ const ModelFileSuffix = ".mod"
 const EntityFileSuffix = ".ent"
 
 type Registry struct {
-	Models   map[string]yaml.Model  `yaml:"models"`
-	Entities map[string]yaml.Entity `yaml:"entities"`
+	mutex sync.RWMutex
+
+	models   map[string]yaml.Model  `yaml:"models"`
+	entities map[string]yaml.Entity `yaml:"entities"`
+}
+
+// SetModel is a thread-safe way to write a model to the registry
+func (r *Registry) SetModel(name string, model yaml.Model) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	r.models[name] = model
+}
+
+// GetModel returns a thread-safe copy of a registry model
+func (r *Registry) GetModel(name string) (yaml.Model, error) {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+	model, modelFound := r.models[name]
+	if !modelFound {
+		return yaml.Model{}, fmt.Errorf("model with name '%s' not found registry", name)
+	}
+	modelClone := model.DeepClone()
+	return modelClone, nil
+}
+
+// GetAllModels returns a thread-safe copy of all registry models
+func (r *Registry) GetAllModels() map[string]yaml.Model {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	modelsClone := clone.DeepCloneMap(r.models)
+	return modelsClone
+}
+
+// SetEntity is a thread-safe way to write an entity to the registry
+func (r *Registry) SetEntity(name string, entity yaml.Entity) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	r.entities[name] = entity
+}
+
+// GetEntity returns a thread-safe copy of a registry entity
+func (r *Registry) GetEntity(name string) (yaml.Entity, error) {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+	entity, entityFound := r.entities[name]
+	if !entityFound {
+		return yaml.Entity{}, fmt.Errorf("entity with name '%s' not found registry", name)
+	}
+	entityClone := entity.DeepClone()
+	return entityClone, nil
+}
+
+// GetAllEntities returns a thread-safe copy of all registry entities
+func (r *Registry) GetAllEntities() map[string]yaml.Entity {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	entitiesClone := clone.DeepCloneMap(r.entities)
+	return entitiesClone
 }
 
 func (r *Registry) DeepClone() *Registry {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
 	registryCopy := &Registry{
-		Models:   clone.DeepCloneMap(r.Models),
-		Entities: clone.DeepCloneMap(r.Entities),
+		models:   clone.DeepCloneMap(r.models),
+		entities: clone.DeepCloneMap(r.entities),
 	}
 
 	return registryCopy
 }
 
-func (registry *Registry) LoadModelsFromDirectory(dirPath string) error {
+func (r *Registry) LoadModelsFromDirectory(dirPath string) error {
 	allModels, unmarshalErr := yamlfile.UnmarshalAllYAMLFiles[yaml.Model](dirPath, ModelFileSuffix)
 	if unmarshalErr != nil {
 		return unmarshalErr
 	}
 
-	loadErr := registry.loadModelDefinitions(allModels)
+	loadErr := r.loadModelDefinitions(allModels)
 	return loadErr
 }
 
-func (registry *Registry) LoadEntitiesFromDirectory(dirPath string) error {
+func (r *Registry) LoadEntitiesFromDirectory(dirPath string) error {
 	allEntities, unmarshalErr := yamlfile.UnmarshalAllYAMLFiles[yaml.Entity](dirPath, EntityFileSuffix)
 	if unmarshalErr != nil {
 		return unmarshalErr
 	}
 
-	loadErr := registry.loadEntityDefinitions(allEntities)
+	loadErr := r.loadEntityDefinitions(allEntities)
 	return loadErr
 }
 
-func (registry *Registry) loadModelDefinitions(allModels map[string]yaml.Model) error {
-	if registry.Models == nil {
-		registry.Models = make(map[string]yaml.Model)
+func (r *Registry) loadModelDefinitions(allModels map[string]yaml.Model) error {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	if r.models == nil {
+		r.models = make(map[string]yaml.Model)
 	}
 
 	for modelPathAbs, model := range allModels {
-		_, nameConflict := registry.Models[model.Name]
+		_, nameConflict := r.models[model.Name]
 		if nameConflict {
 			return fmt.Errorf("model name '%s' already exists in registry (conflict: %s)", model.Name, modelPathAbs)
 		}
 
-		registry.Models[model.Name] = model
+		r.models[model.Name] = model
 	}
 	return nil
 }
 
-func (registry *Registry) loadEntityDefinitions(allEntities map[string]yaml.Entity) error {
-	if registry.Entities == nil {
-		registry.Entities = make(map[string]yaml.Entity)
+func (r *Registry) loadEntityDefinitions(allEntities map[string]yaml.Entity) error {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	if r.entities == nil {
+		r.entities = make(map[string]yaml.Entity)
 	}
 
 	for entityPathAbs, entity := range allEntities {
-		_, nameConflict := registry.Entities[entity.Name]
+		_, nameConflict := r.entities[entity.Name]
 		if nameConflict {
 			return fmt.Errorf("entity name '%s' already exists in registry (conflict: %s)", entity.Name, entityPathAbs)
 		}
 
-		registry.Entities[entity.Name] = entity
+		r.entities[entity.Name] = entity
 	}
 	return nil
 }

--- a/pkg/registry/registry_factory.go
+++ b/pkg/registry/registry_factory.go
@@ -4,7 +4,7 @@ import "github.com/kaloseia/morphe-go/pkg/yaml"
 
 func NewRegistry() *Registry {
 	return &Registry{
-		Models:   map[string]yaml.Model{},
-		Entities: map[string]yaml.Entity{},
+		models:   map[string]yaml.Model{},
+		entities: map[string]yaml.Entity{},
 	}
 }

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -42,11 +42,11 @@ func (suite *RegistryTestSuite) TestLoadModelsFromDirectory() {
 	modelsErr := registry.LoadModelsFromDirectory(suite.ModelsDirPath)
 
 	suite.Nil(modelsErr)
-	suite.Len(registry.Models, 4)
-	suite.Len(registry.Entities, 0)
+	suite.Len(registry.GetAllModels(), 4)
+	suite.Len(registry.GetAllEntities(), 0)
 
-	model0, modelExists0 := registry.Models["Company"]
-	suite.True(modelExists0)
+	model0, modelErr0 := registry.GetModel("Company")
+	suite.Nil(modelErr0)
 	suite.Equal(model0.Name, "Company")
 
 	suite.Len(model0.Fields, 4)
@@ -94,8 +94,8 @@ func (suite *RegistryTestSuite) TestLoadModelsFromDirectory() {
 	suite.True(relatedExists01)
 	suite.Equal(modelRelated01.Type, "HasMany")
 
-	model1, modelExists1 := registry.Models["Address"]
-	suite.True(modelExists1)
+	model1, modelErr1 := registry.GetModel("Address")
+	suite.Nil(modelErr1)
 	suite.Equal(model1.Name, "Address")
 
 	suite.Len(model1.Fields, 3)
@@ -131,8 +131,8 @@ func (suite *RegistryTestSuite) TestLoadModelsFromDirectory() {
 	suite.True(relatedExists10)
 	suite.Equal(modelRelated10.Type, "ForOne")
 
-	model2, modelExists2 := registry.Models["ContactInfo"]
-	suite.True(modelExists2)
+	model2, modelErr2 := registry.GetModel("ContactInfo")
+	suite.Nil(modelErr2)
 	suite.Equal(model2.Name, "ContactInfo")
 
 	suite.Len(model2.Fields, 3)
@@ -165,8 +165,8 @@ func (suite *RegistryTestSuite) TestLoadModelsFromDirectory() {
 	suite.True(relatedExists20)
 	suite.Equal(modelRelated20.Type, "ForOne")
 
-	model3, modelExists3 := registry.Models["Person"]
-	suite.True(modelExists3)
+	model3, modelErr3 := registry.GetModel("Person")
+	suite.Nil(modelErr3)
 	suite.Equal(model3.Name, "Person")
 
 	suite.Len(model3.Fields, 4)
@@ -227,14 +227,14 @@ func (suite *RegistryTestSuite) TestLoadModelsFromDirectory_InvalidDirPath() {
 	modelsErrMsg := modelsErr.Error()
 	suite.Contains(modelsErrMsg, "error reading directory")
 	suite.Contains(modelsErrMsg, "####INVALID/DIR/PATH####")
-	suite.Len(registry.Models, 0)
-	suite.Len(registry.Entities, 0)
+	suite.Len(registry.GetAllModels(), 0)
+	suite.Len(registry.GetAllEntities(), 0)
 }
 
 func (suite *RegistryTestSuite) TestLoadModelsFromDirectory_ConflictingName() {
 	registry := registry.NewRegistry()
 
-	registry.Models["Company"] = yaml.Model{Name: "Company"}
+	registry.SetModel("Company", yaml.Model{Name: "Company"})
 
 	modelsErr := registry.LoadModelsFromDirectory(suite.ModelsDirPath)
 
@@ -252,11 +252,11 @@ func (suite *RegistryTestSuite) TestLoadEntitiesFromDirectory() {
 	entitiesErr := registry.LoadEntitiesFromDirectory(suite.EntitiesDirPath)
 
 	suite.Nil(entitiesErr)
-	suite.Len(registry.Models, 0)
-	suite.Len(registry.Entities, 2)
+	suite.Len(registry.GetAllModels(), 0)
+	suite.Len(registry.GetAllEntities(), 2)
 
-	entity0, entityExists0 := registry.Entities["Company"]
-	suite.True(entityExists0)
+	entity0, entityErr0 := registry.GetEntity("Company")
+	suite.Nil(entityErr0)
 	suite.Equal(entity0.Name, "Company")
 
 	suite.Len(entity0.Fields, 6)
@@ -299,8 +299,8 @@ func (suite *RegistryTestSuite) TestLoadEntitiesFromDirectory() {
 	suite.True(relatedExists00)
 	suite.Equal(entityRelated00.Type, "HasMany")
 
-	entity1, entityExists1 := registry.Entities["Person"]
-	suite.True(entityExists1)
+	entity1, entityErr1 := registry.GetEntity("Person")
+	suite.Nil(entityErr1)
 	suite.Equal(entity1.Name, "Person")
 
 	suite.Len(entity1.Fields, 5)
@@ -348,14 +348,14 @@ func (suite *RegistryTestSuite) TestLoadEntitiesFromDirectory_InvalidDirPath() {
 	entitiesErrMsg := entitiesErr.Error()
 	suite.Contains(entitiesErrMsg, "error reading directory")
 	suite.Contains(entitiesErrMsg, "####INVALID/DIR/PATH####")
-	suite.Len(registry.Models, 0)
-	suite.Len(registry.Entities, 0)
+	suite.Len(registry.GetAllModels(), 0)
+	suite.Len(registry.GetAllEntities(), 0)
 }
 
 func (suite *RegistryTestSuite) TestLoadEntitiesFromDirectory_ConflictingName() {
 	registry := registry.NewRegistry()
 
-	registry.Entities["Company"] = yaml.Entity{Name: "Company"}
+	registry.SetEntity("Company", yaml.Entity{Name: "Company"})
 
 	entitiesErr := registry.LoadEntitiesFromDirectory(suite.EntitiesDirPath)
 

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -366,3 +366,27 @@ func (suite *RegistryTestSuite) TestLoadEntitiesFromDirectory_ConflictingName() 
 	conflictPath := filepath.Join(suite.EntitiesDirPath, "company.ent")
 	suite.Contains(entitiesErrMsg, conflictPath)
 }
+
+func (suite *RegistryTestSuite) TestDeepClone() {
+	registry := registry.NewRegistry()
+
+	modelsErr := registry.LoadModelsFromDirectory(suite.ModelsDirPath)
+	suite.Nil(modelsErr)
+
+	entitiesErr := registry.LoadEntitiesFromDirectory(suite.EntitiesDirPath)
+	suite.Nil(entitiesErr)
+
+	registryClone := registry.DeepClone()
+
+	suite.NotSame(registry, registryClone)
+	suite.Equal(registry, registryClone)
+}
+
+func (suite *RegistryTestSuite) TestDeepClone_Empty() {
+	registry := registry.NewRegistry()
+
+	registryClone := registry.DeepClone()
+
+	suite.NotSame(registry, registryClone)
+	suite.Equal(registry, registryClone)
+}

--- a/pkg/yaml/entity.go
+++ b/pkg/yaml/entity.go
@@ -1,7 +1,21 @@
 package yaml
 
+import (
+	"github.com/kaloseia/morphe-go/pkg/clone"
+)
+
 type Entity struct {
 	Name    string                    `yaml:"name"`
 	Fields  map[string]EntityField    `yaml:"fields"`
 	Related map[string]EntityRelation `yaml:"related"`
+}
+
+func (e Entity) DeepClone() Entity {
+	entityCopy := Entity{
+		Name:    e.Name,
+		Fields:  clone.DeepCloneMap(e.Fields),
+		Related: clone.DeepCloneMap(e.Related),
+	}
+
+	return entityCopy
 }

--- a/pkg/yaml/entity_field.go
+++ b/pkg/yaml/entity_field.go
@@ -1,6 +1,17 @@
 package yaml
 
+import (
+	"github.com/kaloseia/morphe-go/pkg/clone"
+)
+
 type EntityField struct {
 	Type       ModelFieldPath `yaml:"type"`
 	Attributes []string       `yaml:"attributes"`
+}
+
+func (f EntityField) DeepClone() EntityField {
+	return EntityField{
+		Type:       f.Type,
+		Attributes: clone.Slice(f.Attributes),
+	}
 }

--- a/pkg/yaml/entity_relation.go
+++ b/pkg/yaml/entity_relation.go
@@ -3,3 +3,9 @@ package yaml
 type EntityRelation struct {
 	Type string `yaml:"type"`
 }
+
+func (f EntityRelation) DeepClone() EntityRelation {
+	return EntityRelation{
+		Type: f.Type,
+	}
+}

--- a/pkg/yaml/model.go
+++ b/pkg/yaml/model.go
@@ -1,6 +1,10 @@
 package yaml
 
-import "log"
+import (
+	"log"
+
+	"github.com/kaloseia/morphe-go/pkg/clone"
+)
 
 type Model struct {
 	Name        string                     `yaml:"name"`
@@ -9,7 +13,18 @@ type Model struct {
 	Related     map[string]ModelRelation   `yaml:"related"`
 }
 
-func (m *Model) GetIdentifierFields() []ModelField {
+func (m Model) DeepClone() Model {
+	modelCopy := Model{
+		Name:        m.Name,
+		Fields:      clone.DeepCloneMap(m.Fields),
+		Identifiers: clone.DeepCloneMap(m.Identifiers),
+		Related:     clone.DeepCloneMap(m.Related),
+	}
+
+	return modelCopy
+}
+
+func (m Model) GetIdentifierFields() []ModelField {
 	var fields []ModelField
 	for _, identifier := range m.Identifiers {
 		for _, fieldName := range identifier.Fields {

--- a/pkg/yaml/model_field.go
+++ b/pkg/yaml/model_field.go
@@ -1,6 +1,15 @@
 package yaml
 
+import "github.com/kaloseia/morphe-go/pkg/clone"
+
 type ModelField struct {
 	Type       ModelFieldType `yaml:"type"`
 	Attributes []string       `yaml:"attributes"`
+}
+
+func (f ModelField) DeepClone() ModelField {
+	return ModelField{
+		Type:       f.Type,
+		Attributes: clone.Slice(f.Attributes),
+	}
 }

--- a/pkg/yaml/model_identifier.go
+++ b/pkg/yaml/model_identifier.go
@@ -1,9 +1,18 @@
 package yaml
 
-import "gopkg.in/yaml.v3"
+import (
+	"github.com/kaloseia/morphe-go/pkg/clone"
+	"gopkg.in/yaml.v3"
+)
 
 type ModelIdentifier struct {
 	Fields []string
+}
+
+func (id ModelIdentifier) DeepClone() ModelIdentifier {
+	return ModelIdentifier{
+		Fields: clone.Slice(id.Fields),
+	}
 }
 
 func (id *ModelIdentifier) UnmarshalYAML(value *yaml.Node) error {

--- a/pkg/yaml/model_relation.go
+++ b/pkg/yaml/model_relation.go
@@ -3,3 +3,9 @@ package yaml
 type ModelRelation struct {
 	Type string `yaml:"type"`
 }
+
+func (r ModelRelation) DeepClone() ModelRelation {
+	return ModelRelation{
+		Type: r.Type,
+	}
+}


### PR DESCRIPTION
Making Morphe registry thread-safe so that plugins and modules have the option to process in parallel, for example compiling multiple independent Go structs.