### PR TITLE
feat: relation attributes, relation identifiers

### DIFF
--- a/pkg/yaml/entity.go
+++ b/pkg/yaml/entity.go
@@ -59,6 +59,9 @@ func (e Entity) validateAllIdentifiers() error {
 			return ErrNoMorpheEntityIdentifierFields(e.Name, identifierName)
 		}
 		for _, fieldName := range identifier.Fields {
+			if strings.HasPrefix(fieldName, "rel:") {
+				return ErrMorpheEntityIdentifierRelPrefix(e.Name, identifierName, fieldName)
+			}
 			if _, exists := e.Fields[fieldName]; !exists {
 				return ErrUnknownMorpheEntityIdentifierField(e.Name, identifierName, fieldName)
 			}

--- a/pkg/yaml/entity_errors.go
+++ b/pkg/yaml/entity_errors.go
@@ -71,3 +71,7 @@ func ErrMorpheEntityUnknownAliasedTarget(entityName string, relationName string,
 func ErrMorpheEntityPolymorphicInverseValidation(entityName string, relationName string, aliasedTarget string, through string, reason string) error {
 	return fmt.Errorf("morphe entity '%s' polymorphic inverse relation '%s' (aliased: %s, through: %s): %s", entityName, relationName, aliasedTarget, through, reason)
 }
+
+func ErrMorpheEntityIdentifierRelPrefix(entityName string, identifierName string, fieldName string) error {
+	return fmt.Errorf("entity '%s' identifier '%s' field '%s' uses 'rel:' prefix which is not supported for entity identifiers", entityName, identifierName, fieldName)
+}

--- a/pkg/yaml/entity_relation.go
+++ b/pkg/yaml/entity_relation.go
@@ -3,17 +3,19 @@ package yaml
 import "github.com/kalo-build/clone"
 
 type EntityRelation struct {
-	Type    string   `yaml:"type"`
-	For     []string `yaml:"for,omitempty"`
-	Through string   `yaml:"through,omitempty"`
-	Aliased string   `yaml:"aliased,omitempty"`
+	Type       string   `yaml:"type"`
+	For        []string `yaml:"for,omitempty"`
+	Through    string   `yaml:"through,omitempty"`
+	Aliased    string   `yaml:"aliased,omitempty"`
+	Attributes []string `yaml:"attributes,omitempty"`
 }
 
 func (f EntityRelation) DeepClone() EntityRelation {
 	return EntityRelation{
-		Type:    f.Type,
-		For:     clone.Slice(f.For),
-		Through: f.Through,
-		Aliased: f.Aliased,
+		Type:       f.Type,
+		For:        clone.Slice(f.For),
+		Through:    f.Through,
+		Aliased:    f.Aliased,
+		Attributes: clone.Slice(f.Attributes),
 	}
 }

--- a/pkg/yaml/entity_test.go
+++ b/pkg/yaml/entity_test.go
@@ -992,3 +992,39 @@ func TestEntityValidate_AliasedFieldPath_NonPolyMalformedAlias(t *testing.T) {
 	assert.Contains(t, err.Error(), "aliased target model .Contact")
 	assert.Contains(t, err.Error(), "does not exist")
 }
+
+func TestEntityValidate_IdentifierRelPrefixRejected(t *testing.T) {
+	personModel := Model{
+		Name: "Person",
+		Fields: map[string]ModelField{
+			"ID":   {Type: "AutoIncrement"},
+			"Name": {Type: "String"},
+		},
+		Identifiers: map[string]ModelIdentifier{
+			"primary": {Fields: []string{"ID"}},
+		},
+	}
+
+	entity := Entity{
+		Name: "Person",
+		Fields: map[string]EntityField{
+			"ID":   {Type: "Person.ID"},
+			"Name": {Type: "Person.Name"},
+		},
+		Identifiers: map[string]EntityIdentifier{
+			"primary": {Fields: []string{"ID"}},
+			"test":    {Fields: []string{"rel:Company"}},
+		},
+		Related: map[string]EntityRelation{
+			"Company": {Type: "ForOne"},
+		},
+	}
+
+	allModels := map[string]Model{"Person": personModel}
+	allEntities := map[string]Entity{"Person": entity}
+
+	err := entity.Validate(allEntities, allModels, map[string]Enum{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rel:")
+	assert.Contains(t, err.Error(), "not supported for entity identifiers")
+}

--- a/pkg/yaml/model.go
+++ b/pkg/yaml/model.go
@@ -25,8 +25,9 @@ func (m Model) Validate(allEnums map[string]Enum) error {
 	if len(m.Identifiers) == 0 {
 		return ErrNoMorpheModelIdentifiers
 	}
-	if len(allEnums) == 0 {
-		return nil
+
+	if err := m.validateAllIdentifiers(); err != nil {
+		return err
 	}
 
 	fieldTypesErr := m.validateFieldTypes(allEnums)
@@ -118,6 +119,10 @@ func (m Model) isRelationHas(relationType string) bool {
 	return strings.HasPrefix(strings.ToLower(relationType), "has")
 }
 
+func (m Model) isRelationOne(relationType string) bool {
+	return strings.Contains(strings.ToLower(relationType), "one")
+}
+
 func (m Model) isRelationPoly(relationType string) bool {
 	lowerType := strings.ToLower(relationType)
 	return (m.isRelationFor(relationType) || m.isRelationHas(relationType)) &&
@@ -143,10 +148,35 @@ func (m Model) DeepClone() Model {
 	return modelCopy
 }
 
+func (m Model) validateAllIdentifiers() error {
+	for identifierName, identifier := range m.Identifiers {
+		for _, field := range identifier.Fields {
+			if strings.HasPrefix(field, "rel:") {
+				relationName := strings.TrimPrefix(field, "rel:")
+				relation, exists := m.Related[relationName]
+				if !exists {
+					return ErrMorpheModelIdentifierRelationNotFound(m.Name, identifierName, relationName)
+				}
+				if !m.isRelationFor(relation.Type) || !m.isRelationOne(relation.Type) {
+					return ErrMorpheModelIdentifierRelationInvalidType(m.Name, identifierName, relationName, relation.Type)
+				}
+			} else {
+				if _, exists := m.Fields[field]; !exists {
+					return ErrMorpheModelIdentifierFieldNotFound(m.Name, identifierName, field)
+				}
+			}
+		}
+	}
+	return nil
+}
+
 func (m Model) GetIdentifierFields() []ModelField {
 	var fields []ModelField
 	for _, identifier := range m.Identifiers {
 		for _, fieldName := range identifier.Fields {
+			if strings.HasPrefix(fieldName, "rel:") {
+				continue
+			}
 			idField, fieldExists := m.Fields[fieldName]
 			if !fieldExists {
 				log.Printf("identifier field '%s' does not exist in model '%s'", fieldName, m.Name)

--- a/pkg/yaml/model_errors.go
+++ b/pkg/yaml/model_errors.go
@@ -20,3 +20,15 @@ func ErrMorpheModelUnknownAliasedTarget(modelName string, relationName string, a
 func ErrMorpheModelPolymorphicInverseValidation(modelName string, relationName string, aliasedTarget string, through string, reason string) error {
 	return fmt.Errorf("morphe model '%s' polymorphic inverse relation '%s' (aliased: %s, through: %s): %s", modelName, relationName, aliasedTarget, through, reason)
 }
+
+func ErrMorpheModelIdentifierFieldNotFound(modelName string, identifierName string, fieldName string) error {
+	return fmt.Errorf("morphe model '%s' identifier '%s' references unknown field '%s'", modelName, identifierName, fieldName)
+}
+
+func ErrMorpheModelIdentifierRelationNotFound(modelName string, identifierName string, relationName string) error {
+	return fmt.Errorf("morphe model '%s' identifier '%s' references unknown relation 'rel:%s'", modelName, identifierName, relationName)
+}
+
+func ErrMorpheModelIdentifierRelationInvalidType(modelName string, identifierName string, relationName string, relationType string) error {
+	return fmt.Errorf("morphe model '%s' identifier '%s' references relation '%s' with unsupported type '%s' (only ForOne and ForOnePoly may be used in identifiers)", modelName, identifierName, relationName, relationType)
+}

--- a/pkg/yaml/model_relation.go
+++ b/pkg/yaml/model_relation.go
@@ -3,17 +3,19 @@ package yaml
 import "github.com/kalo-build/clone"
 
 type ModelRelation struct {
-	Type    string   `yaml:"type"`
-	For     []string `yaml:"for,omitempty"`
-	Through string   `yaml:"through,omitempty"`
-	Aliased string   `yaml:"aliased,omitempty"`
+	Type       string   `yaml:"type"`
+	For        []string `yaml:"for,omitempty"`
+	Through    string   `yaml:"through,omitempty"`
+	Aliased    string   `yaml:"aliased,omitempty"`
+	Attributes []string `yaml:"attributes,omitempty"`
 }
 
 func (r ModelRelation) DeepClone() ModelRelation {
 	return ModelRelation{
-		Type:    r.Type,
-		For:     clone.Slice(r.For),
-		Through: r.Through,
-		Aliased: r.Aliased,
+		Type:       r.Type,
+		For:        clone.Slice(r.For),
+		Through:    r.Through,
+		Aliased:    r.Aliased,
+		Attributes: clone.Slice(r.Attributes),
 	}
 }

--- a/pkg/yaml/model_test.go
+++ b/pkg/yaml/model_test.go
@@ -399,6 +399,114 @@ func TestModelValidateWithModels_PolymorphicInverseAliasing_ModelNotInForList(t 
 	assert.Contains(t, err.Error(), "current model 'Post' is not in the 'for' list")
 }
 
+func TestModelValidate_IdentifierFieldExists(t *testing.T) {
+	model := Model{
+		Name: "Task",
+		Fields: map[string]ModelField{
+			"ID":    {Type: "UUID"},
+			"Title": {Type: "String"},
+		},
+		Identifiers: map[string]ModelIdentifier{
+			"primary": {Fields: []string{"ID"}},
+		},
+	}
+	err := model.Validate(map[string]Enum{})
+	assert.NoError(t, err)
+}
+
+func TestModelValidate_IdentifierFieldNotFound(t *testing.T) {
+	model := Model{
+		Name: "Task",
+		Fields: map[string]ModelField{
+			"ID": {Type: "UUID"},
+		},
+		Identifiers: map[string]ModelIdentifier{
+			"primary": {Fields: []string{"ID"}},
+			"name":    {Fields: []string{"MissingField"}},
+		},
+	}
+	err := model.Validate(map[string]Enum{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "references unknown field 'MissingField'")
+}
+
+func TestModelValidate_IdentifierRelPrefixValid(t *testing.T) {
+	model := Model{
+		Name: "TaskTag",
+		Fields: map[string]ModelField{
+			"ID": {Type: "UUID"},
+		},
+		Identifiers: map[string]ModelIdentifier{
+			"primary": {Fields: []string{"ID"}},
+			"taskTag": {Fields: []string{"rel:Task", "rel:Tag"}},
+		},
+		Related: map[string]ModelRelation{
+			"Task": {Type: "ForOne"},
+			"Tag":  {Type: "ForOne"},
+		},
+	}
+	err := model.Validate(map[string]Enum{})
+	assert.NoError(t, err)
+}
+
+func TestModelValidate_IdentifierRelPrefixForOnePoly(t *testing.T) {
+	model := Model{
+		Name: "Reaction",
+		Fields: map[string]ModelField{
+			"ID":   {Type: "UUID"},
+			"Kind": {Type: "String"},
+		},
+		Identifiers: map[string]ModelIdentifier{
+			"primary":  {Fields: []string{"ID"}},
+			"reaction": {Fields: []string{"rel:Reactable", "Kind"}},
+		},
+		Related: map[string]ModelRelation{
+			"Reactable": {Type: "ForOnePoly", For: []string{"Post", "Comment"}},
+		},
+	}
+	err := model.Validate(map[string]Enum{})
+	assert.NoError(t, err)
+}
+
+func TestModelValidate_IdentifierRelPrefixRelationNotFound(t *testing.T) {
+	model := Model{
+		Name: "TaskTag",
+		Fields: map[string]ModelField{
+			"ID": {Type: "UUID"},
+		},
+		Identifiers: map[string]ModelIdentifier{
+			"primary": {Fields: []string{"ID"}},
+			"taskTag": {Fields: []string{"rel:Task", "rel:MissingRelation"}},
+		},
+		Related: map[string]ModelRelation{
+			"Task": {Type: "ForOne"},
+		},
+	}
+	err := model.Validate(map[string]Enum{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "references unknown relation 'rel:MissingRelation'")
+}
+
+func TestModelValidate_IdentifierRelPrefixInvalidRelationType(t *testing.T) {
+	model := Model{
+		Name: "Task",
+		Fields: map[string]ModelField{
+			"ID": {Type: "UUID"},
+		},
+		Identifiers: map[string]ModelIdentifier{
+			"primary":  {Fields: []string{"ID"}},
+			"taskUser": {Fields: []string{"rel:User"}},
+		},
+		Related: map[string]ModelRelation{
+			"User": {Type: "HasMany"},
+		},
+	}
+	err := model.Validate(map[string]Enum{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported type 'HasMany'")
+	assert.Contains(t, err.Error(), "only ForOne and ForOnePoly")
+}
+
 func TestModelValidateWithModels_AliasedRelation_WhitespaceHandling(t *testing.T) {
 	// Setup test models
 	contactModel := Model{

--- a/pkg/yamlops/relation_test.go
+++ b/pkg/yamlops/relation_test.go
@@ -123,7 +123,7 @@ func TestIsRelationAliased(t *testing.T) {
 func TestGetRelationTargetName(t *testing.T) {
 	// When aliased is provided, should return aliased target
 	assert.Equal(t, "ContactInfo", GetRelationTargetName("WorkContact", "ContactInfo"))
-	assert.Equal(t, "Project", GetRelationTargetName("WorkProjects", "Project"))
+	assert.Equal(t, "Project", GetRelationTargetName("WorkProject", "Project"))
 	assert.Equal(t, "User", GetRelationTargetName("Author", "User"))
 
 	// When aliased is empty, should return relationship name


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Extends the YAML schema for relations and changes model/entity validation around identifiers, which could reject previously accepted configs and impact codegen/runtime behavior. Risk is moderated by added unit tests covering the new validation rules.
> 
> **Overview**
> Adds an optional `attributes` list to `ModelRelation` and `EntityRelation` (including deep-clone support), extending the YAML relation schema.
> 
> Tightens identifier validation: models now validate that identifier fields exist and may include `rel:<Relation>` entries only when the relation exists and is `ForOne`/`ForOnePoly`; entity identifiers explicitly reject any `rel:` usage with a new error. Updates tests accordingly and adjusts `GetIdentifierFields` to ignore `rel:` entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43b01e0d1111ac9d0fde1dd2bd469dfd152c1abc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->